### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,16 @@ I also want to thank the following authors/scripts/plugins for making my coding 
 Warning: Before checking out the repo, please make sure you have a basic understanding of HTML, CSS, PHP and jQuery (and C++)
 
 # Changed
-###v1.6
+### v1.6
 Analog ports are now called using 0-15 (for arduino mega), adding the A for analog will not work anymore and should be avoided
 Also changed some bugs in the Arduino Code.      
               
-###v1.5     
+### v1.5     
 From this version on, I've changed the way analog ports can be used as digital ports. If you want to use a analog port as
 a digital port then include the real value of the analog port. For example on my Arduino MEga 2560 I have 52 digital ports,
 port 53 is my A0 port and so on.
 
-##More Information & Options
+## More Information & Options
 Check my blog for more information how to use the API: [blog](http://www.fritz-hut.com/all-projects/arduinopi/)       
 More information on how to connect the Raspberry Pi with the Arduino and how everything works can be found on my blog:
 [fritz-hut](http://fritz-hut.com).         


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
